### PR TITLE
Add support for when backdrop switches to block

### DIFF
--- a/example-project/Giga/Giga.js
+++ b/example-project/Giga/Giga.js
@@ -11,7 +11,12 @@ export default class Giga extends Sprite {
 
     this.triggers = [
       new Trigger(Trigger.CLICKED, this.whenthisspriteclicked),
-      new Trigger(Trigger.GREEN_FLAG, this.whenGreenFlagClicked)
+      new Trigger(Trigger.GREEN_FLAG, this.whenGreenFlagClicked),
+      new Trigger(
+        Trigger.BACKDROP_CHANGED,
+        { backdrop: "giga" },
+        this.whenBackdropChanged
+      )
     ];
 
     this.visible = false;
@@ -23,5 +28,9 @@ export default class Giga extends Sprite {
 
   *whenGreenFlagClicked() {
     this.costume = "giga-a";
+  }
+
+  *whenBackdropChanged() {
+      yield* this.sayAndWait("It's me!", 2);
   }
 }

--- a/example-project/Gobo/Gobo.js
+++ b/example-project/Gobo/Gobo.js
@@ -12,7 +12,12 @@ export default class Gobo extends Sprite {
 
     this.triggers = [
       new Trigger(Trigger.CLICKED, this.whenthisspriteclicked),
-      new Trigger(Trigger.GREEN_FLAG, this.whenGreenFlagClicked)
+      new Trigger(Trigger.GREEN_FLAG, this.whenGreenFlagClicked),
+      new Trigger(
+        Trigger.BACKDROP_CHANGED,
+        { backdrop: "gobo" },
+        this.whenBackdropChanged
+      )
     ];
 
     this.visible = false;
@@ -24,5 +29,9 @@ export default class Gobo extends Sprite {
 
   *whenGreenFlagClicked() {
     this.costume = "goboA";
+  }
+
+  *whenBackdropChanged() {
+      yield* this.sayAndWait("It's me!", 2);
   }
 }

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -97,6 +97,7 @@ class SpriteBase {
 
   set costumeNumber(number) {
     this._costumeNumber = ((number - 1) % this.costumes.length) + 1;
+    if (this.fireBackdropChanged) this.fireBackdropChanged();
   }
 
   set costume(costume) {
@@ -645,5 +646,11 @@ export class Stage extends SpriteBase {
 
     // For obsolete counter blocks.
     this.__counter = 0;
+  }
+
+  fireBackdropChanged() {
+    this._project.fireTrigger(Trigger.BACKDROP_CHANGED, {
+      backdrop: this.costume.name
+    });
   }
 }

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -649,7 +649,7 @@ export class Stage extends SpriteBase {
   }
 
   fireBackdropChanged() {
-    this._project.fireTrigger(Trigger.BACKDROP_CHANGED, {
+    return this._project.fireTrigger(Trigger.BACKDROP_CHANGED, {
       backdrop: this.costume.name
     });
   }

--- a/src/Trigger.js
+++ b/src/Trigger.js
@@ -4,6 +4,7 @@ const BROADCAST = Symbol("BROADCAST");
 const CLICKED = Symbol("CLICKED");
 const CLONE_START = Symbol("CLONE_START");
 const TIMER_GREATER_THAN = Symbol("TIMER_GREATER_THAN");
+const BACKDROP_CHANGED = Symbol("BACKDROP_CHANGED");
 
 export default class Trigger {
   constructor(trigger, options, script) {
@@ -84,5 +85,8 @@ export default class Trigger {
   }
   static get TIMER_GREATER_THAN() {
     return TIMER_GREATER_THAN;
+  }
+  static get BACKDROP_CHANGED() {
+    return BACKDROP_CHANGED;
   }
 }


### PR DESCRIPTION
This adds support for "when backdrop switches to" block. (example project uses it!) This also changes costume setter to check the sprite type (stage/normal sprite) so that you can't use `next costume` in stage, and removes `random costume` because it's not used in scratch-vm.