### PR TITLE
Fix for #59: Add if on edge, bounce

### DIFF
--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -634,7 +634,7 @@ export class Sprite extends SpriteBase {
   keepInFence(newX, newY) {
     // https://github.com/LLK/scratch-vm/blob/develop/src/sprites/rendered-target.js#L949
     const fence = this.stage.fence;
-    const bounds = this._project.renderer.getBoundingBox(this);
+    const bounds = this._project.renderer.getTightBoundingBox(this);
     bounds.left += newX - this.x;
     bounds.right += newX - this.x;
     bounds.top += newY - this.y;

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -760,7 +760,7 @@ export class Sprite extends SpriteBase {
   }
 
   nearestEdge() {
-    const bounds = this._project.renderer.getBoundingBox(this);
+    const bounds = this._project.renderer.getTightBoundingBox(this);
     const { width: stageWidth, height: stageHeight } = this.stage;
     const distLeft = Math.max(0, stageWidth / 2 + bounds.left);
     const distTop = Math.max(0, stageHeight / 2 - bounds.top);

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -614,20 +614,20 @@ export class Sprite extends SpriteBase {
     let dy = -Math.sin(rad);
     switch (nearestEdge) {
       case Sprite.Edge.LEFT:
-      dx = Math.max(0.2, Math.abs(dx));
-      break;
+        dx = Math.max(0.2, Math.abs(dx));
+        break;
       case Sprite.Edge.RIGHT:
-      dx = -Math.max(0.2, Math.abs(dx));
-      break;
+        dx = -Math.max(0.2, Math.abs(dx));
+        break;
       case Sprite.Edge.TOP:
-      dy = Math.max(0.2, Math.abs(dy));
-      break;
+        dy = Math.max(0.2, Math.abs(dy));
+        break;
       case Sprite.Edge.BOTTOM:
-      dy = -Math.max(0.2, Math.abs(dy));
-      break;
+        dy = -Math.max(0.2, Math.abs(dy));
+        break;
     }
     this.direction = this.degToScratch(this.radToDeg(Math.atan2(dy, dx)));
-    const {x, y} = this.keepInFence(this.x, this.y);
+    const { x, y } = this.keepInFence(this.x, this.y);
     this.goto(x, y);
   }
 
@@ -635,12 +635,13 @@ export class Sprite extends SpriteBase {
     // https://github.com/LLK/scratch-vm/blob/develop/src/sprites/rendered-target.js#L949
     const fence = this.stage.fence;
     const bounds = this._project.renderer.getBoundingBox(this);
-    bounds.left += (newX - this.x);
-    bounds.right += (newX - this.x);
-    bounds.top += (newY - this.y);
-    bounds.bottom += (newY - this.y);
+    bounds.left += newX - this.x;
+    bounds.right += newX - this.x;
+    bounds.top += newY - this.y;
+    bounds.bottom += newY - this.y;
 
-    let dx = 0, dy = 0;
+    let dx = 0,
+      dy = 0;
     if (bounds.left < fence.left) {
       dx += fence.left - bounds.left;
     }
@@ -653,10 +654,10 @@ export class Sprite extends SpriteBase {
     if (bounds.bottom < fence.bottom) {
       dy += fence.bottom - bounds.bottom;
     }
-    return ({
+    return {
       x: newX + dx,
       y: newY + dy
-    });
+    };
   }
 
   get penDown() {
@@ -759,35 +760,35 @@ export class Sprite extends SpriteBase {
   }
 
   nearestEdge() {
-      const bounds = this._project.renderer.getBoundingBox(this);
-      const {width: stageWidth, height: stageHeight} = this.stage;
-      const distLeft = Math.max(0, (stageWidth / 2) + bounds.left);
-      const distTop = Math.max(0, (stageHeight / 2) - bounds.top);
-      const distRight = Math.max(0, (stageWidth / 2) - bounds.right);
-      const distBottom = Math.max(0, (stageHeight / 2) + bounds.bottom);
-      // Find the nearest edge.
-      let nearestEdge = '';
-      let minDist = Infinity;
-      if (distLeft < minDist) {
-        minDist = distLeft;
-        nearestEdge = Sprite.Edge.LEFT;
-      }
-      if (distTop < minDist) {
-        minDist = distTop;
-        nearestEdge = Sprite.Edge.TOP;
-      }
-      if (distRight < minDist) {
-        minDist = distRight;
-        nearestEdge = Sprite.Edge.RIGHT;
-      }
-      if (distBottom < minDist) {
-        minDist = distBottom;
-        nearestEdge = Sprite.Edge.BOTTOM;
-      }
-      if (minDist > 0) {
-        nearestEdge = null;
-      }
-      return nearestEdge;
+    const bounds = this._project.renderer.getBoundingBox(this);
+    const { width: stageWidth, height: stageHeight } = this.stage;
+    const distLeft = Math.max(0, stageWidth / 2 + bounds.left);
+    const distTop = Math.max(0, stageHeight / 2 - bounds.top);
+    const distRight = Math.max(0, stageWidth / 2 - bounds.right);
+    const distBottom = Math.max(0, stageHeight / 2 + bounds.bottom);
+    // Find the nearest edge.
+    let nearestEdge = "";
+    let minDist = Infinity;
+    if (distLeft < minDist) {
+      minDist = distLeft;
+      nearestEdge = Sprite.Edge.LEFT;
+    }
+    if (distTop < minDist) {
+      minDist = distTop;
+      nearestEdge = Sprite.Edge.TOP;
+    }
+    if (distRight < minDist) {
+      minDist = distRight;
+      nearestEdge = Sprite.Edge.RIGHT;
+    }
+    if (distBottom < minDist) {
+      minDist = distBottom;
+      nearestEdge = Sprite.Edge.BOTTOM;
+    }
+    if (minDist > 0) {
+      nearestEdge = null;
+    }
+    return nearestEdge;
   }
 
   say(text) {

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -790,10 +790,6 @@ export class Sprite extends SpriteBase {
       return nearestEdge;
   }
 
-  touchingEdge() {
-    return !!this.nearestEdge();
-  }
-
   say(text) {
     clearTimeout(this._speechBubble.timeout);
     this._speechBubble = { text: String(text), style: "say", timeout: null };

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -606,6 +606,59 @@ export class Sprite extends SpriteBase {
     } while (t < 1);
   }
 
+  ifOnEdgeBounce() {
+    const nearestEdge = this.nearestEdge();
+    if (!nearestEdge) return;
+    const rad = this.degToRad(this.scratchToDeg(this.direction));
+    let dx = Math.cos(rad);
+    let dy = -Math.sin(rad);
+    switch (nearestEdge) {
+      case Sprite.Edge.LEFT:
+      dx = Math.max(0.2, Math.abs(dx));
+      break;
+      case Sprite.Edge.RIGHT:
+      dx = -Math.max(0.2, Math.abs(dx));
+      break;
+      case Sprite.Edge.TOP:
+      dy = Math.max(0.2, Math.abs(dy));
+      break;
+      case Sprite.Edge.BOTTOM:
+      dy = -Math.max(0.2, Math.abs(dy));
+      break;
+    }
+    this.direction = this.degToScratch(this.radToDeg(Math.atan2(dy, dx)));
+    const {x, y} = this.keepInFence(this.x, this.y);
+    this.goto(x, y);
+  }
+
+  keepInFence(newX, newY) {
+    // https://github.com/LLK/scratch-vm/blob/develop/src/sprites/rendered-target.js#L949
+    const fence = this.stage.fence;
+    const bounds = this._project.renderer.getBoundingBox(this);
+    bounds.left += (newX - this.x);
+    bounds.right += (newX - this.x);
+    bounds.top += (newY - this.y);
+    bounds.bottom += (newY - this.y);
+
+    let dx = 0, dy = 0;
+    if (bounds.left < fence.left) {
+      dx += fence.left - bounds.left;
+    }
+    if (bounds.right > fence.right) {
+      dx += fence.right - bounds.right;
+    }
+    if (bounds.top > fence.top) {
+      dy += fence.top - bounds.top;
+    }
+    if (bounds.bottom < fence.bottom) {
+      dy += fence.bottom - bounds.bottom;
+    }
+    return ({
+      x: newX + dx,
+      y: newY + dy
+    });
+  }
+
   get penDown() {
     return this._penDown;
   }
@@ -705,6 +758,42 @@ export class Sprite extends SpriteBase {
     }
   }
 
+  nearestEdge() {
+      const bounds = this._project.renderer.getBoundingBox(this);
+      const {width: stageWidth, height: stageHeight} = this.stage;
+      const distLeft = Math.max(0, (stageWidth / 2) + bounds.left);
+      const distTop = Math.max(0, (stageHeight / 2) - bounds.top);
+      const distRight = Math.max(0, (stageWidth / 2) - bounds.right);
+      const distBottom = Math.max(0, (stageHeight / 2) + bounds.bottom);
+      // Find the nearest edge.
+      let nearestEdge = '';
+      let minDist = Infinity;
+      if (distLeft < minDist) {
+        minDist = distLeft;
+        nearestEdge = Sprite.Edge.LEFT;
+      }
+      if (distTop < minDist) {
+        minDist = distTop;
+        nearestEdge = Sprite.Edge.TOP;
+      }
+      if (distRight < minDist) {
+        minDist = distRight;
+        nearestEdge = Sprite.Edge.RIGHT;
+      }
+      if (distBottom < minDist) {
+        minDist = distBottom;
+        nearestEdge = Sprite.Edge.BOTTOM;
+      }
+      if (minDist > 0) {
+        nearestEdge = null;
+      }
+      return nearestEdge;
+  }
+
+  touchingEdge() {
+    return !!this.nearestEdge();
+  }
+
   say(text) {
     clearTimeout(this._speechBubble.timeout);
     this._speechBubble = { text: String(text), style: "say", timeout: null };
@@ -750,6 +839,13 @@ Sprite.RotationStyle = Object.freeze({
   DONT_ROTATE: Symbol("DONT_ROTATE")
 });
 
+Sprite.Edge = Object.freeze({
+  BOTTOM: Symbol("BOTTOM"),
+  LEFT: Symbol("LEFT"),
+  RIGHT: Symbol("RIGHT"),
+  TOP: Symbol("TOP")
+});
+
 export class Stage extends SpriteBase {
   constructor(initialConditions, ...args) {
     super(initialConditions, ...args);
@@ -777,5 +873,13 @@ export class Stage extends SpriteBase {
     return this._project.fireTrigger(Trigger.BACKDROP_CHANGED, {
       backdrop: this.costume.name
     });
+  }
+  get fence() {
+    return {
+      left: -this.width / 2,
+      right: this.width / 2,
+      top: this.height / 2,
+      bottom: -this.height / 2
+    };
   }
 }

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -863,6 +863,13 @@ export class Stage extends SpriteBase {
       }
     });
 
+    this.fence = {
+      left: -this.width / 2,
+      right: this.width / 2,
+      top: this.height / 2,
+      bottom: -this.height / 2
+    };
+
     this.name = "Stage";
 
     // For obsolete counter blocks.
@@ -873,13 +880,5 @@ export class Stage extends SpriteBase {
     return this._project.fireTrigger(Trigger.BACKDROP_CHANGED, {
       backdrop: this.costume.name
     });
-  }
-  get fence() {
-    return {
-      left: -this.width / 2,
-      right: this.width / 2,
-      top: this.height / 2,
-      bottom: -this.height / 2
-    };
   }
 }

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -609,9 +609,9 @@ export class Sprite extends SpriteBase {
   ifOnEdgeBounce() {
     const nearestEdge = this.nearestEdge();
     if (!nearestEdge) return;
-    const rad = this.degToRad(this.scratchToDeg(this.direction));
+    const rad = this.scratchToRad(this.direction);
     let dx = Math.cos(rad);
-    let dy = -Math.sin(rad);
+    let dy = Math.sin(rad);
     switch (nearestEdge) {
       case Sprite.Edge.LEFT:
         dx = Math.max(0.2, Math.abs(dx));
@@ -620,13 +620,13 @@ export class Sprite extends SpriteBase {
         dx = -Math.max(0.2, Math.abs(dx));
         break;
       case Sprite.Edge.TOP:
-        dy = Math.max(0.2, Math.abs(dy));
-        break;
-      case Sprite.Edge.BOTTOM:
         dy = -Math.max(0.2, Math.abs(dy));
         break;
+      case Sprite.Edge.BOTTOM:
+        dy = Math.max(0.2, Math.abs(dy));
+        break;
     }
-    this.direction = this.degToScratch(this.radToDeg(Math.atan2(dy, dx)));
+    this.direction = this.radToScratch(Math.atan2(dy, dx));
     const { x, y } = this.keepInFence(this.x, this.y);
     this.goto(x, y);
   }

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -627,18 +627,13 @@ export class Sprite extends SpriteBase {
         break;
     }
     this.direction = this.radToScratch(Math.atan2(dy, dx));
-    const { x, y } = this.keepInFence(this.x, this.y);
-    this.goto(x, y);
+    this.positionInFence();
   }
 
-  keepInFence(newX, newY) {
+  positionInFence() {
     // https://github.com/LLK/scratch-vm/blob/develop/src/sprites/rendered-target.js#L949
     const fence = this.stage.fence;
     const bounds = this._project.renderer.getTightBoundingBox(this);
-    bounds.left += newX - this.x;
-    bounds.right += newX - this.x;
-    bounds.top += newY - this.y;
-    bounds.bottom += newY - this.y;
 
     let dx = 0,
       dy = 0;
@@ -654,10 +649,8 @@ export class Sprite extends SpriteBase {
     if (bounds.bottom < fence.bottom) {
       dy += fence.bottom - bounds.bottom;
     }
-    return {
-      x: newX + dx,
-      y: newY + dy
-    };
+
+    this.goto(this.x + dx, this.y + dy);
   }
 
   get penDown() {


### PR DESCRIPTION
Fixes #59 to finish implementing the "if on edge, bounce" block.

There was a minor issue with the math where we needed to flip the y-axis, because Leopard and the Scratch VM use different signs for the internal representation of the y-axis.

Also ran through Prettier to clean up the formatting.