### PR TITLE
Add support for "when timer greater than"

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -103,11 +103,11 @@ export default class Project {
     const edgeActivated = this._matchingTriggers(tr => tr.isEdgeActivated);
     const triggersToStart = [];
     for (const triggerWithTarget of edgeActivated) {
-      const { trigger } = triggerWithTarget;
+      const { trigger, target } = triggerWithTarget;
       let predicate;
       switch (trigger.trigger) {
         case Trigger.TIMER_GREATER_THAN:
-          predicate = this.timer > trigger.option("VALUE");
+          predicate = this.timer > trigger.option("VALUE", target);
           break;
         default:
           throw new Error(`Unimplemented trigger ${trigger.trigger}`);

--- a/src/Sprite.js
+++ b/src/Sprite.js
@@ -236,8 +236,7 @@ class SpriteBase {
   }
 
   get timer() {
-    const ms = new Date() - this._project.timerStart;
-    return ms / 1000;
+    return this._project.timer;
   }
 
   restartTimer() {
@@ -396,7 +395,7 @@ export class Sprite extends SpriteBase {
 
     // Trigger CLONE_START:
     const triggers = clone.triggers.filter(tr =>
-      tr.matches(Trigger.CLONE_START)
+      tr.matches(Trigger.CLONE_START, {}, clone)
     );
     this._project._startTriggers(
       triggers.map(trigger => ({ trigger, target: clone }))

--- a/src/Trigger.js
+++ b/src/Trigger.js
@@ -3,6 +3,7 @@ const KEY_PRESSED = Symbol("KEY_PRESSED");
 const BROADCAST = Symbol("BROADCAST");
 const CLICKED = Symbol("CLICKED");
 const CLONE_START = Symbol("CLONE_START");
+const TIMER_GREATER_THAN = Symbol("TIMER_GREATER_THAN");
 
 export default class Trigger {
   constructor(trigger, options, script) {
@@ -20,10 +21,26 @@ export default class Trigger {
     this.stop = () => {};
   }
 
-  matches(trigger, options) {
+  get isEdgeActivated() {
+    return this.trigger === TIMER_GREATER_THAN;
+  }
+
+  // Evaluate the given trigger option, whether it's a value or a function that
+  // returns a value given a target
+  option(option, target) {
+    let triggerOption = this.options[option];
+    // If the given option is a function, evaluate that function, passing in
+    // the target that we're evaluating the trigger for
+    if (typeof triggerOption === "function") {
+      return triggerOption(target);
+    }
+    return triggerOption;
+  }
+
+  matches(trigger, options, target) {
     if (this.trigger !== trigger) return false;
     for (let option in options) {
-      if (this.options[option] !== options[option]) return false;
+      if (this.option(option, target) !== options[option]) return false;
     }
 
     return true;
@@ -64,5 +81,8 @@ export default class Trigger {
   }
   static get CLONE_START() {
     return CLONE_START;
+  }
+  static get TIMER_GREATER_THAN() {
+    return TIMER_GREATER_THAN;
   }
 }


### PR DESCRIPTION
Resolves part of #122.

This PR adds support for "edge-activated" triggers, so named because they evaluate a predicate every step (e.g. "is the timer greater than N?") and trigger their script on the rising edge (when the predicate changes from `false` to `true`).

Trigger predicates/options can now be functions (which are passed the current target) as well as values. This is necessary because the input to a "greater than" block is actually droppable and can contain arbitrary scripts. For codegen purposes, it may be easier to have the function take *no* arguments and just bind the `this` value to the current target, but that seems jankier.