### PR TITLE
Make "when this sprite clicked" only fire for the topmost sprite under the mouse

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -1,7 +1,6 @@
 import Trigger from "./Trigger.js";
 import Renderer from "./Renderer.js";
 import Input from "./Input.js";
-import { Stage } from "./Sprite.js";
 
 export default class Project {
   constructor(stage, sprites = {}, { frameRate = 30 } = {}) {
@@ -41,37 +40,16 @@ export default class Project {
   attach(renderTarget) {
     this.renderer.setRenderTarget(renderTarget);
     this.renderer.stage.addEventListener("click", () => {
-      const wasClicked = sprite => {
-        if (sprite instanceof Stage) {
-          return true;
-        }
+      const clickedSprite = this.renderer.pick(this.spritesAndStage, {
+        x: this.input.mouse.x,
+        y: this.input.mouse.y
+      });
+      if (!clickedSprite) return;
 
-        return this.renderer.checkPointCollision(
-          sprite,
-          {
-            x: this.input.mouse.x,
-            y: this.input.mouse.y
-          },
-          false
-        );
-      };
-
-      let matchingTriggers = [];
-      for (let i = 0; i < this.spritesAndStage.length; i++) {
-        const sprite = this.spritesAndStage[i];
-        const spriteClickedTriggers = sprite.triggers.filter(tr =>
-          tr.matches(Trigger.CLICKED, {}, sprite)
-        );
-        if (spriteClickedTriggers.length > 0) {
-          if (wasClicked(sprite)) {
-            matchingTriggers = [
-              ...matchingTriggers,
-              ...spriteClickedTriggers.map(trigger => ({
-                trigger,
-                target: sprite
-              }))
-            ];
-          }
+      const matchingTriggers = [];
+      for (const trigger of clickedSprite.triggers) {
+        if (trigger.matches(Trigger.CLICKED, {}, clickedSprite)) {
+          matchingTriggers.push({ trigger, target: clickedSprite });
         }
       }
 

--- a/src/renderer/ShaderManager.js
+++ b/src/renderer/ShaderManager.js
@@ -69,15 +69,12 @@ class ShaderManager {
     } else {
       let shaderCode;
       switch (drawMode) {
-        case ShaderManager.DrawModes.DEFAULT:
-        case ShaderManager.DrawModes.SILHOUETTE:
-        case ShaderManager.DrawModes.COLOR_MASK: {
-          shaderCode = SpriteShader;
-          break;
-        }
-
         case ShaderManager.DrawModes.PEN_LINE: {
           shaderCode = PenLineShader;
+          break;
+        }
+        default: {
+          shaderCode = SpriteShader;
           break;
         }
       }
@@ -128,6 +125,9 @@ ShaderManager.DrawModes = {
   // Used for "color is touching color" tests. Only renders sprite colors which are close to the color passed in, and
   // discards all pixels of a different color.
   COLOR_MASK: "COLOR_MASK",
+  // Used for picking the topmost sprite and identifying which one it is.
+  // Assigns a color to each sprite.
+  SPRITE_ID: "SPRITE_ID",
   // Used for drawing pen lines.
   PEN_LINE: "PEN_LINE"
 };

--- a/src/renderer/Shaders.js
+++ b/src/renderer/Shaders.js
@@ -65,6 +65,10 @@ uniform vec4 u_colorMask;
 const vec3 COLOR_MASK_TOLERANCE = vec3(3.0 / 255.0);
 #endif
 
+#ifdef DRAW_MODE_SPRITE_ID
+uniform vec3 u_spriteId;
+#endif
+
 #ifdef EFFECT_color
 // Taken from http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 vec3 rgb2hsv(vec3 c)
@@ -171,6 +175,10 @@ void main() {
   if (color.a == 0.0) {
     discard;
   }
+  #endif
+
+  #ifdef DRAW_MODE_SPRITE_ID
+  color = color.a > 0.0 ? vec4(u_spriteId, 1.0) : vec4(0.0, 0.0, 0.0, 0.0);
   #endif
 
   gl_FragColor = color;


### PR DESCRIPTION
Resolves #77

In Scratch, "when this sprite clicked" triggers are only activated on the topmost sprite under the mouse. In Leopard, they were previously triggered for every sprite under the mouse.

To fix this, I added a `pick` method to the renderer that assigns each sprite a color, renders the scene, then maps the color under the mouse pointer back to its corresponding sprite. This will always return whichever sprite is on top.