### PR TITLE
Take min/max in slider Watcher constructor

### DIFF
--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -9,6 +9,8 @@ export default class Watcher {
     visible = true,
     color = Color.rgb(255, 140, 26),
     step = 1,
+    min = 0,
+    max = 100,
     x = -240,
     y = 180,
     width,
@@ -25,6 +27,8 @@ export default class Watcher {
     this.visible = visible;
     this.color = color;
     this.step = step;
+    this.min = min;
+    this.max = max;
 
     this.x = x;
     this.y = y;


### PR DESCRIPTION
Support for leopard-js/sb-edit#90. This is needed to pass min/max values from deserialized projects (sb3) to Leopard. The actual implementation for min/max is already implemented, and `step` is already passed through the constructor.