### PR TITLE
Add `"types"` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "browser": true,
   "files": [
     "dist/"


### PR DESCRIPTION
Resolves #191

Just adds the `"types"` field to the `package.json` so that the types get exposed to people using the library.

~~Not tested yet, but should work~~
Tested and works.