### PR TITLE
Defend renderer against NaN or non-number sprite size

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -59,6 +59,8 @@ export default class Renderer {
   private _drawables: WeakMap<Sprite | Stage, Drawable>;
   private _skins: WeakMap<object, Skin>;
 
+  private _warnedBadSize: WeakSet<Sprite | Stage>;
+
   private _currentShader: Shader | null;
   private _currentFramebuffer: WebGLFramebuffer | null;
   private _screenSpaceScale: number;
@@ -86,6 +88,8 @@ export default class Renderer {
     this._shaderManager = new ShaderManager(this);
     this._drawables = new WeakMap();
     this._skins = new WeakMap();
+
+    this._warnedBadSize = new WeakSet();
 
     this._currentShader = null;
     this._currentFramebuffer = null;
@@ -503,10 +507,16 @@ export default class Renderer {
   private _getSpriteScale(sprite: Sprite | Stage): number {
     if ("size" in sprite) {
       if (typeof sprite.size !== "number") {
-        console.warn(`Expected a number, sprite ${sprite.constructor.name} size is ${typeof sprite.size}. Treating as 100%.`);
+        if (!this._warnedBadSize.has(sprite)) {
+          console.warn(`Expected a number, sprite ${sprite.constructor.name} size is ${typeof sprite.size}. Treating as 100%.`);
+          this._warnedBadSize.add(sprite);
+        }
         return 1;
       } else if (isNaN(sprite.size)) {
-        console.warn(`Expected a number, sprite ${sprite.constructor.name} size is NaN. Treating as 100%.`);
+        if (!this._warnedBadSize.has(sprite)) {
+          console.warn(`Expected a number, sprite ${sprite.constructor.name} size is NaN. Treating as 100%.`);
+          this._warnedBadSize.add(sprite);
+        }
         return 1;
       } else {
         return sprite.size / 100;

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -500,17 +500,31 @@ export default class Renderer {
     this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
   }
 
+  private _getSpriteScale(sprite: Sprite | Stage): number {
+    if ("size" in sprite) {
+      if (typeof sprite.size !== "number") {
+        console.warn(`Expected a number, sprite ${sprite.constructor.name} size is ${typeof sprite.size}. Treating as 100%.`);
+        return 1;
+      } else if (isNaN(sprite.size)) {
+        console.warn(`Expected a number, sprite ${sprite.constructor.name} size is NaN. Treating as 100%.`);
+        return 1;
+      } else {
+        return sprite.size / 100;
+      }
+    } else {
+      return 1;
+    }
+  }
+
   private renderSprite(
     sprite: Sprite | Stage,
     options: RenderSpriteOptions
   ): void {
-    const spriteScale = "size" in sprite ? sprite.size / 100 : 1;
-
     this._renderSkin(
       this._getSkin(sprite.costume),
       options.drawMode,
       this._getDrawable(sprite).getMatrix(),
-      spriteScale,
+      this._getSpriteScale(sprite),
       sprite.effects,
       options.effectMask,
       options.colorMask,

--- a/src/renderer/Skin.ts
+++ b/src/renderer/Skin.ts
@@ -31,7 +31,7 @@ export default abstract class Skin {
     filtering:
       | WebGLRenderingContext["NEAREST"]
       | WebGLRenderingContext["LINEAR"]
-  ): WebGLTexture {
+  ): WebGLTexture | null {
     const gl = this.gl;
     const glTexture = gl.createTexture();
     if (!glTexture) throw new Error("Could not create texture");
@@ -43,7 +43,7 @@ export default abstract class Skin {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filtering);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filtering);
-    if (image)
+    if (image) {
       gl.texImage2D(
         gl.TEXTURE_2D,
         0,
@@ -52,6 +52,12 @@ export default abstract class Skin {
         gl.UNSIGNED_BYTE,
         image
       );
+      const error = gl.getError();
+      if (error) {
+        console.warn(`Skin._makeTexture failed - WebGL code: ${error}`);
+        return null;
+      }
+    }
 
     return glTexture;
   }

--- a/src/renderer/SpeechBubbleSkin.ts
+++ b/src/renderer/SpeechBubbleSkin.ts
@@ -149,6 +149,11 @@ export default class SpeechBubbleSkin extends Skin {
   }
 
   public getTexture(scale: number): WebGLTexture | null {
+    if (isNaN(scale)) {
+      console.warn(`SpeechBubbleSkin.getTexture got unexpected NaN scale`);
+      return null;
+    }
+
     if (!this._rendered || this._renderedScale !== scale) {
       this._renderBubble(this._bubble, scale);
       const gl = this.gl;

--- a/src/renderer/SpeechBubbleSkin.ts
+++ b/src/renderer/SpeechBubbleSkin.ts
@@ -148,7 +148,7 @@ export default class SpeechBubbleSkin extends Skin {
     this._renderedScale = scale;
   }
 
-  public getTexture(scale: number): WebGLTexture {
+  public getTexture(scale: number): WebGLTexture | null {
     if (!this._rendered || this._renderedScale !== scale) {
       this._renderBubble(this._bubble, scale);
       const gl = this.gl;

--- a/src/renderer/SpeechBubbleSkin.ts
+++ b/src/renderer/SpeechBubbleSkin.ts
@@ -14,7 +14,7 @@ const bubbleStyle = {
 export default class SpeechBubbleSkin extends Skin {
   private _canvas: HTMLCanvasElement;
   private _ctx: CanvasRenderingContext2D;
-  private _texture: WebGLTexture;
+  private _texture: WebGLTexture | null;
   private _bubble: SpeechBubble;
   private _flipped: boolean;
   private _rendered: boolean;

--- a/src/renderer/VectorSkin.ts
+++ b/src/renderer/VectorSkin.ts
@@ -87,12 +87,15 @@ export default class VectorSkin extends Skin {
   private _createMipmap(mipLevel: number): void {
     // Instead of uploading the image to WebGL as a texture, render the image to a canvas and upload the canvas.
     const ctx = this._drawSvgToCanvas(mipLevel);
-    this._mipmaps.set(
-      mipLevel,
-      // Use linear (i.e. smooth) texture filtering for vectors
-      // If the image is 0x0, we return null. Check for that.
-      ctx === null ? null : this._makeTexture(ctx.canvas, this.gl.LINEAR)
-    );
+
+    // If the image is 0x0, we return null. Check for that.
+    if (ctx === null) {
+      this._mipmaps.set(mipLevel, null);
+      return;
+    }
+
+    // Use linear (i.e. smooth) texture filtering for vectors.
+    this._mipmaps.set(mipLevel, this._makeTexture(ctx.canvas, this.gl.LINEAR));
   }
 
   public getTexture(scale: number): WebGLTexture | null {

--- a/src/renderer/VectorSkin.ts
+++ b/src/renderer/VectorSkin.ts
@@ -84,18 +84,17 @@ export default class VectorSkin extends Skin {
 
   // TODO: handle proper subpixel positioning when SVG viewbox has non-integer coordinates
   // This will require rethinking costume + project loading probably
-  private _createMipmap(mipLevel: number): void {
+  private _createMipmap(mipLevel: number): WebGLTexture | null {
     // Instead of uploading the image to WebGL as a texture, render the image to a canvas and upload the canvas.
     const ctx = this._drawSvgToCanvas(mipLevel);
 
     // If the image is 0x0, we return null. Check for that.
     if (ctx === null) {
-      this._mipmaps.set(mipLevel, null);
-      return;
+      return null;
     }
 
     // Use linear (i.e. smooth) texture filtering for vectors.
-    this._mipmaps.set(mipLevel, this._makeTexture(ctx.canvas, this.gl.LINEAR));
+    return this._makeTexture(ctx.canvas, this.gl.LINEAR);
   }
 
   public getTexture(scale: number): WebGLTexture | null {
@@ -109,7 +108,9 @@ export default class VectorSkin extends Skin {
     // This means that one texture pixel will always be between 0.5x and 1x the size of one rendered pixel,
     // but never bigger than one rendered pixel--this prevents blurriness from blowing up the texture too much.
     const mipLevel = VectorSkin.mipLevelForScale(scale);
-    if (!this._mipmaps.has(mipLevel)) this._createMipmap(mipLevel);
+    if (!this._mipmaps.has(mipLevel)) {
+      this._mipmaps.set(mipLevel, this._createMipmap(mipLevel));
+    }
 
     return this._mipmaps.get(mipLevel) ?? null;
   }

--- a/src/renderer/VectorSkin.ts
+++ b/src/renderer/VectorSkin.ts
@@ -100,6 +100,11 @@ export default class VectorSkin extends Skin {
   public getTexture(scale: number): WebGLTexture | null {
     if (!this._image.complete) return null;
 
+    if (isNaN(scale)) {
+      console.warn(`VectorSkin.getTexture got unexpected NaN scale`);
+      return null;
+    }
+
     // Because WebGL doesn't support vector graphics, substitute a bunch of bitmaps.
     // This skin contains several renderings of its image at different scales.
     // We render the SVG at 0.5x scale, 1x scale, 2x scale, 4x scale, etc. and store those as textures,


### PR DESCRIPTION
Related to leopard-js/leopard-mentors#4.

The main substantive change here is that `Renderer.renderSprite` will now always treat sprites with NaN or non-number `size` as being 100%. This isn't "right" per se - "set size to NaN" is [equal](https://github.com/scratchfoundation/scratch-vm/blob/bc07dd09fe27083af0ce4d217f531f79286817f9/src/blocks/scratch3_looks.js#L566) to "set size to 0" - but sprites should never be size NaN anyway, and I figure "treating as 100%" is more clearly-broken behavior than "treating as literally invisible". (Matching Scratch exactly would mean setting the size to the minimum valid size for that sprite, which the renderer isn't suited to handle.)

Secondary changes include warnings in the `SpeechBubbleSkin.getTexture` and `VectorSkin.getTexture` interfaces, which expect a non-NaN scale, and some light refactoring for `VectorSkin._getMipmap` and `Renderer.renderSprite`.

This doesn't fix the case project (leopard-js/leopard-mentors#4), but it does clarify the error from a generic `WebGL: INVALID_VALUE: texImage2D: no canvas` into `Expected a number, sprite TiledChevron size is NaN. Treating as 100%.`.