### PR TITLE
Implement Scratch-like sequencer behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c --watch",
-    "lint": "eslint \"./src/**.ts\"",
+    "lint": "eslint \"./src/**/*.ts\"",
     "prepare": "npm run build"
   },
   "devDependencies": {

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -137,7 +137,9 @@ export default class Project {
     triggerMatches: (tr: Trigger, target: Sprite | Stage) => boolean
   ): TriggerWithTarget[] {
     const matchingTriggers: TriggerWithTarget[] = [];
-    for (const target of this.targets) {
+    // Iterate over targets in top-down order, as Scratch does
+    for (let i = this.targets.length - 1; i >= 0; i--) {
+      const target = this.targets[i];
       const matchingTargetTriggers = target.triggers.filter((tr) =>
         triggerMatches(tr, target)
       );

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -133,10 +133,11 @@ export default class Project {
       let predicate;
       switch (trigger.trigger) {
         case Trigger.TIMER_GREATER_THAN:
-          predicate = this.timer > trigger.option("VALUE", target)!;
+          predicate = this.timer > (trigger.option("VALUE", target) as number);
           break;
         case Trigger.LOUDNESS_GREATER_THAN:
-          predicate = this.loudness > trigger.option("VALUE", target)!;
+          predicate =
+            this.loudness > (trigger.option("VALUE", target) as number);
           break;
         default:
           throw new Error(`Unimplemented trigger ${String(trigger.trigger)}`);

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -27,7 +27,8 @@ export default class Project {
   private loudnessHandler: LoudnessHandler;
   private _cachedLoudness: number | null;
 
-  public threads: Thread[];
+  private threads: Thread[];
+  private redrawRequested: boolean;
 
   public answer: string | null;
   private timerStart!: Date;
@@ -61,7 +62,7 @@ export default class Project {
     });
     for (const target of this.targets) {
       target.clearInitialLayerOrder();
-      target._project = this;
+      target.setProject(this);
     }
 
     Object.freeze(sprites); // Prevent adding/removing sprites while project is running
@@ -76,6 +77,7 @@ export default class Project {
     this._cachedLoudness = null;
 
     this.threads = [];
+    this.redrawRequested = false;
     this._prevStepTriggerPredicates = new WeakMap();
 
     this.restartTimer();
@@ -196,6 +198,8 @@ export default class Project {
     this.threads = this.threads.filter(
       (thread) => thread.status !== ThreadStatus.DONE
     );
+
+    this.redrawRequested = false;
   }
 
   private render(): void {
@@ -320,6 +324,10 @@ export default class Project {
     for (const target of this.targets) {
       callback(target);
     }
+  }
+
+  public requestRedraw(): void {
+    this.redrawRequested = true;
   }
 
   public stopAllSounds(): void {

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -273,8 +273,7 @@ export default class Project {
       this.filterSprites((sprite) => {
         if (!sprite.isOriginal) return false;
 
-        sprite.effects.clear();
-        sprite.audioEffects.clear();
+        sprite.reset();
         return true;
       });
     }

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -303,37 +303,33 @@ export default class Renderer {
         (filter && !filter(layer))
       );
 
-    // Stage
-    if (shouldIncludeLayer(this.project.stage)) {
-      this.renderSprite(this.project.stage, options);
-    }
+    this.project.forEachTarget((target) => {
+      // TODO: just make a `visible` getter for Stage to avoid this rigmarole
+      const visible = "visible" in target ? target.visible : true;
 
-    // Pen layer
-    if (shouldIncludeLayer(this._penSkin)) {
-      const penMatrix = Matrix.create();
-      Matrix.scale(
-        penMatrix,
-        penMatrix,
-        this._penSkin.width,
-        -this._penSkin.height
-      );
-      Matrix.translate(penMatrix, penMatrix, -0.5, -0.5);
-
-      this._renderSkin(
-        this._penSkin,
-        options.drawMode,
-        penMatrix,
-        1 /* scale */
-      );
-    }
-
-    // Sprites + clones
-    for (const sprite of this.project.spritesAndClones) {
-      // Stage doesn't have "visible" defined, so check if it's strictly false
-      if (shouldIncludeLayer(sprite) && sprite.visible !== false) {
-        this.renderSprite(sprite, options);
+      if (shouldIncludeLayer(target) && visible) {
+        this.renderSprite(target, options);
       }
-    }
+
+      // Draw the pen layer in front of the stage
+      if (target instanceof Stage && shouldIncludeLayer(this._penSkin)) {
+        const penMatrix = Matrix.create();
+        Matrix.scale(
+          penMatrix,
+          penMatrix,
+          this._penSkin.width,
+          -this._penSkin.height
+        );
+        Matrix.translate(penMatrix, penMatrix, -0.5, -0.5);
+
+        this._renderSkin(
+          this._penSkin,
+          options.drawMode,
+          penMatrix,
+          1 /* scale */
+        );
+      }
+    });
   }
 
   private _updateStageSize(): void {

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -163,9 +163,7 @@ export default class Renderer {
   public _createFramebufferInfo(
     width: number,
     height: number,
-    filtering:
-      | WebGLRenderingContext["NEAREST"]
-      | WebGLRenderingContext["LINEAR"],
+    filtering: number,
     stencil = false
   ): FramebufferInfo {
     // Create an empty texture with this skin's dimensions.

--- a/src/Sprite.ts
+++ b/src/Sprite.ts
@@ -1,14 +1,14 @@
 import Color from "./Color";
-import Trigger, { RunStatus } from "./Trigger";
+import Trigger from "./Trigger";
 import Sound, { EffectChain, AudioEffectMap } from "./Sound";
 import Costume from "./Costume";
 import type { Mouse } from "./Input";
 import type Project from "./Project";
+import Thread, { ThreadStatus } from "./Thread";
 import type Watcher from "./Watcher";
 import type { Yielding } from "./lib/yielding";
 
 import { effectNames } from "./renderer/effectInfo";
-import { TriggerWithTarget } from "./Project";
 
 type Effects = {
   [x in typeof effectNames[number]]: number;
@@ -375,10 +375,10 @@ abstract class SpriteBase {
     }
   }
 
-  public *waitForTriggers(triggers: TriggerWithTarget[]): Yielding<void> {
+  public *waitForThreads(threads: Thread[]): Yielding<void> {
     while (true) {
-      for (const trigger of triggers) {
-        if (trigger.trigger.status !== RunStatus.DONE) {
+      for (const thread of threads) {
+        if (thread.status !== ThreadStatus.DONE) {
           yield;
         }
       }
@@ -387,7 +387,7 @@ abstract class SpriteBase {
   }
 
   public broadcast(name: string): Yielding<void> {
-    return this.waitForTriggers(
+    return this.waitForThreads(
       this._project.fireTrigger(Trigger.BROADCAST, { name })
     );
   }
@@ -637,7 +637,7 @@ export class Sprite extends SpriteBase {
     const triggers = clone.triggers.filter((tr) =>
       tr.matches(Trigger.CLONE_START, {}, clone)
     );
-    void this._project._startTriggers(
+    void this._project._startThreads(
       triggers.map((trigger) => ({ trigger, target: clone }))
     );
   }
@@ -1013,7 +1013,7 @@ export class Stage extends SpriteBase {
   }
 
   public fireBackdropChanged(): Yielding<void> {
-    return this.waitForTriggers(
+    return this.waitForThreads(
       this._project.fireTrigger(Trigger.BACKDROP_CHANGED, {
         backdrop: this.costume.name,
       })

--- a/src/Sprite.ts
+++ b/src/Sprite.ts
@@ -168,6 +168,11 @@ abstract class SpriteBase {
     this._initialLayerOrder = null;
   }
 
+  public reset(): void {
+    this.effects.clear();
+    this.audioEffects.clear();
+  }
+
   protected getSoundsPlayedByMe(): Sound[] {
     return this.sounds.filter((sound) => this.effectChain.isTargetOf(sound));
   }
@@ -613,6 +618,11 @@ export class Sprite extends SpriteBase {
 
   public get isOriginal(): boolean {
     return this.original === this;
+  }
+
+  public reset(): void {
+    super.reset();
+    this._speechBubble = undefined;
   }
 
   public *askAndWait(question: string): Yielding<void> {

--- a/src/Sprite.ts
+++ b/src/Sprite.ts
@@ -101,6 +101,7 @@ abstract class SpriteBase {
   public _project!: Project;
 
   protected _costumeNumber: number;
+  // TODO: remove this and just store the sprites in layer order, as Scratch does.
   public _layerOrder: number;
   public triggers: Trigger[];
   public watchers: Partial<Record<string, Watcher>>;

--- a/src/Sprite.ts
+++ b/src/Sprite.ts
@@ -97,10 +97,11 @@ type InitialConditions = {
 };
 
 abstract class SpriteBase {
-  protected _project!: Project;
+  // TODO: make this protected and pass it in via the constructor
+  public _project!: Project;
 
   protected _costumeNumber: number;
-  protected _layerOrder: number;
+  public _layerOrder: number;
   public triggers: Trigger[];
   public watchers: Partial<Record<string, Watcher>>;
   protected costumes: Costume[];
@@ -701,7 +702,7 @@ export class Sprite extends SpriteBase {
     } while (t < 1);
   }
 
-  ifOnEdgeBounce() {
+  public ifOnEdgeBounce(): void {
     const nearestEdge = this.nearestEdge();
     if (!nearestEdge) return;
     const rad = this.scratchToRad(this.direction);
@@ -725,7 +726,7 @@ export class Sprite extends SpriteBase {
     this.positionInFence();
   }
 
-  positionInFence() {
+  private positionInFence(): void {
     // https://github.com/LLK/scratch-vm/blob/develop/src/sprites/rendered-target.js#L949
     const fence = this.stage.fence;
     const bounds = this._project.renderer.getTightBoundingBox(this);
@@ -869,7 +870,7 @@ export class Sprite extends SpriteBase {
     }
   }
 
-  nearestEdge() {
+  private nearestEdge(): symbol | null {
     const bounds = this._project.renderer.getTightBoundingBox(this);
     const { width: stageWidth, height: stageHeight } = this.stage;
     const distLeft = Math.max(0, stageWidth / 2 + bounds.left);
@@ -953,7 +954,7 @@ export class Sprite extends SpriteBase {
     BOTTOM: Symbol("BOTTOM"),
     LEFT: Symbol("LEFT"),
     RIGHT: Symbol("RIGHT"),
-    TOP: Symbol("TOP")
+    TOP: Symbol("TOP"),
   });
 }
 
@@ -971,7 +972,7 @@ export class Stage extends SpriteBase {
     right: number;
     top: number;
     bottom: number;
-  }
+  };
 
   public constructor(initialConditions: StageInitialConditions, vars = {}) {
     super(initialConditions, vars);
@@ -993,7 +994,7 @@ export class Stage extends SpriteBase {
       left: -this.width / 2,
       right: this.width / 2,
       top: this.height / 2,
-      bottom: -this.height / 2
+      bottom: -this.height / 2,
     };
 
     // For obsolete counter blocks.

--- a/src/Sprite.ts
+++ b/src/Sprite.ts
@@ -101,7 +101,6 @@ export type SpeechBubbleStyle = "say" | "think";
 export type SpeechBubble = {
   text: string;
   style: SpeechBubbleStyle;
-  timeout: number | null;
 };
 
 type InitialConditions = {
@@ -612,7 +611,6 @@ export class Sprite extends SpriteBase {
     this._speechBubble = {
       text: "",
       style: "say",
-      timeout: null,
     };
   }
 
@@ -648,7 +646,6 @@ export class Sprite extends SpriteBase {
     clone._speechBubble = {
       text: "",
       style: "say",
-      timeout: null,
     };
 
     clone.effects = this.effects._clone(clone);
@@ -982,50 +979,40 @@ export class Sprite extends SpriteBase {
   }
 
   public say(text: string): void {
-    if (this._speechBubble?.timeout) clearTimeout(this._speechBubble.timeout);
-    this._speechBubble = { text: String(text), style: "say", timeout: null };
+    this._speechBubble = { text: String(text), style: "say" };
     this._project.requestRedraw();
   }
 
   public think(text: string): void {
-    if (this._speechBubble?.timeout) clearTimeout(this._speechBubble.timeout);
-    this._speechBubble = { text: String(text), style: "think", timeout: null };
+    this._speechBubble = { text: String(text), style: "think" };
     this._project.requestRedraw();
   }
 
   public *sayAndWait(text: string, seconds: number): Yielding<void> {
-    if (this._speechBubble?.timeout) clearTimeout(this._speechBubble.timeout);
-
-    const speechBubble: SpeechBubble = { text, style: "say", timeout: null };
+    const speechBubble: SpeechBubble = { text, style: "say" };
     let done = false;
-    const timeout = window.setTimeout(() => {
-      speechBubble.text = "";
-      speechBubble.timeout = null;
+    window.setTimeout(() => {
       done = true;
     }, seconds * 1000);
 
-    speechBubble.timeout = timeout;
     this._speechBubble = speechBubble;
     this._project.requestRedraw();
     while (!done) yield;
+    speechBubble.text = "";
     this._project.requestRedraw();
   }
 
   public *thinkAndWait(text: string, seconds: number): Yielding<void> {
-    if (this._speechBubble?.timeout) clearTimeout(this._speechBubble.timeout);
-
-    const speechBubble: SpeechBubble = { text, style: "think", timeout: null };
+    const speechBubble: SpeechBubble = { text, style: "think" };
     let done = false;
-    const timeout = window.setTimeout(() => {
-      speechBubble.text = "";
-      speechBubble.timeout = null;
+    window.setTimeout(() => {
       done = true;
     }, seconds * 1000);
 
-    speechBubble.timeout = timeout;
     this._speechBubble = speechBubble;
     this._project.requestRedraw();
     while (!done) yield;
+    speechBubble.text = "";
     this._project.requestRedraw();
   }
 

--- a/src/Thread.ts
+++ b/src/Thread.ts
@@ -1,0 +1,39 @@
+import { Sprite, Stage } from "./Sprite";
+import Trigger from "./Trigger";
+
+export enum ThreadStatus {
+  /** This script is currently running. */
+  RUNNING,
+  /**
+   * This script is waiting for a promise, or waiting for other scripts.
+   * @todo This requires runtime support.
+   */
+  // PARKED,
+  /** This script is finished running. */
+  DONE,
+}
+
+export default class Thread {
+  public target: Sprite | Stage;
+  public trigger: Trigger;
+  public status: ThreadStatus;
+  private runningScript: Generator;
+
+  public constructor(trigger: Trigger, target: Sprite | Stage) {
+    this.runningScript = trigger.startScript(target);
+    this.trigger = trigger;
+    this.target = target;
+    this.status = ThreadStatus.RUNNING;
+  }
+
+  public step(): void {
+    if (this.runningScript.next().done) {
+      this.status = ThreadStatus.DONE;
+    }
+  }
+
+  public restart(): void {
+    this.runningScript = this.trigger.startScript(this.target);
+    this.status = ThreadStatus.RUNNING;
+  }
+}

--- a/src/Thread.ts
+++ b/src/Thread.ts
@@ -1,39 +1,215 @@
+import { Yielding } from "./lib/yielding";
 import { Sprite, Stage } from "./Sprite";
 import Trigger from "./Trigger";
 
 export enum ThreadStatus {
   /** This script is currently running. */
   RUNNING,
-  /**
-   * This script is waiting for a promise, or waiting for other scripts.
-   * @todo This requires runtime support.
-   */
-  // PARKED,
+  /** This script is waiting for a promise, or waiting for other scripts. */
+  PARKED,
   /** This script is finished running. */
   DONE,
 }
 
+const YIELD_TO = Symbol("YIELD_TO");
+const PROMISE_WAIT = Symbol("PROMISE_WAIT");
+
+/**
+ * Yielding these special values from a thread will pause the thread's execution
+ * until some conditions are met.
+ */
+export type ThreadEffect =
+  | {
+      type: typeof YIELD_TO;
+      thread: Thread;
+    }
+  | {
+      type: typeof PROMISE_WAIT;
+      promise: Promise<unknown>;
+    };
+
+const isThreadEffect = (value: unknown): value is ThreadEffect =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  typeof value.type === "symbol";
+
+enum CompletionKind {
+  FULFILLED,
+  REJECTED,
+}
+
 export default class Thread {
+  /** The sprite or stage that this thread's script is part of. */
   public target: Sprite | Stage;
+  /** The trigger that started this thread. Used to restart it. */
   public trigger: Trigger;
-  public status: ThreadStatus;
+  /** This thread's status. Exposed as a getter and setStatus function. */
+  private _status: ThreadStatus;
+  /** The generator function that's currently executing. */
   private runningScript: Generator;
+  /**
+   * If this thread was waiting for a promise, the resolved value of that
+   * promise. It will be passed into the generator function (or thrown, if it's
+   * an error).
+   */
+  private resolvedValue: { type: CompletionKind; value: unknown } | null;
+  /**
+   * Callback functions to execute once this thread exits the "parked" status.
+   */
+  private onUnpark: (() => void)[];
+  /**
+   * Incremented when this thread is restarted; used when resuming from
+   * promises. If the generation counter is different from what it was when the
+   * promise started, we don't do anything with the resolved value.
+   */
+  private generation: number;
 
   public constructor(trigger: Trigger, target: Sprite | Stage) {
     this.runningScript = trigger.startScript(target);
     this.trigger = trigger;
     this.target = target;
-    this.status = ThreadStatus.RUNNING;
+    this._status = ThreadStatus.RUNNING;
+    this.resolvedValue = null;
+    this.generation = 0;
+    this.onUnpark = [];
   }
 
+  private unpark(): void {
+    for (const callback of this.onUnpark) {
+      callback();
+    }
+    this.onUnpark.length = 0;
+  }
+
+  public get status(): ThreadStatus {
+    return this._status;
+  }
+
+  /**
+   * Set the thread's status. This is a function and not a setter to make it
+   * clearer that it has side effects (potentially calling "on unpark"
+   * callbacks).
+   * @param newStatus The status to set.
+   */
+  public setStatus(newStatus: ThreadStatus): void {
+    if (
+      this._status === ThreadStatus.PARKED &&
+      newStatus !== ThreadStatus.PARKED
+    ) {
+      this.unpark();
+    }
+    this._status = newStatus;
+  }
+
+  /**
+   * Step this thread once. Does nothing if the status is not RUNNING (e.g. the
+   * thread is waiting for a promise to resolve).
+   */
   public step(): void {
-    if (this.runningScript.next().done) {
-      this.status = ThreadStatus.DONE;
+    if (this._status !== ThreadStatus.RUNNING) return;
+
+    let next;
+
+    // Pass a promise's resolved value into the generator depending on whether
+    // it fulfilled or rejected.
+    if (this.resolvedValue !== null) {
+      if (this.resolvedValue.type === CompletionKind.REJECTED) {
+        // If the promise rejected, throw the error inside the generator.
+        next = this.runningScript.throw(this.resolvedValue.value);
+      } else {
+        next = this.runningScript.next(this.resolvedValue.value);
+      }
+      this.resolvedValue = null;
+    } else {
+      next = this.runningScript.next();
+    }
+
+    if (next.done) {
+      this.setStatus(ThreadStatus.DONE);
+    } else if (isThreadEffect(next.value)) {
+      switch (next.value.type) {
+        case PROMISE_WAIT: {
+          // Wait for the promise to resolve then pass its value back into the generator.
+          this.setStatus(ThreadStatus.PARKED);
+          const generation = this.generation;
+          next.value.promise.then(
+            (value) => {
+              // If the thread has been restarted since the promise was created,
+              // do nothing.
+              if (this.generation !== generation) return;
+              this.resolvedValue = { type: CompletionKind.FULFILLED, value };
+              this.setStatus(ThreadStatus.RUNNING);
+            },
+            (err) => {
+              if (this.generation !== generation) return;
+              this.resolvedValue = {
+                type: CompletionKind.REJECTED,
+                value: err,
+              };
+              this.setStatus(ThreadStatus.RUNNING);
+            }
+          );
+          break;
+        }
+        case YIELD_TO: {
+          // If the given thread is parked, park ourselves and wait for it to unpark.
+          if (next.value.thread.status === ThreadStatus.PARKED) {
+            this.setStatus(ThreadStatus.PARKED);
+            next.value.thread.onUnpark.push(() => {
+              this.setStatus(ThreadStatus.RUNNING);
+              this.unpark();
+            });
+          }
+        }
+      }
+    }
+    this.resolvedValue = null;
+  }
+
+  /**
+   * Await a promise and pass the result back into the generator.
+   * @param promise The promise to await.
+   * @returns Generator which yields the resolved value.
+   */
+  public static *await<T>(promise: Promise<T>): Generator<ThreadEffect, T, T> {
+    return yield { type: PROMISE_WAIT, promise };
+  }
+
+  /**
+   * If run inside another thread, waits for *this* thread to make progress.
+   */
+  public *yieldTo(): Yielding<void> {
+    yield { type: YIELD_TO, thread: this };
+  }
+
+  /**
+   * If run inside another thread, waits until *this* thread is done running.
+   */
+  public *waitUntilDone(): Yielding<void> {
+    while (this.status !== ThreadStatus.DONE) {
+      yield* this.yieldTo();
     }
   }
 
+  /**
+   * Wait for all the given threads to finish executing.
+   * @param threads The threads to wait for.
+   */
+  public static *waitForThreads(threads: Thread[]): Yielding<void> {
+    for (const thread of threads) {
+      if (thread.status !== ThreadStatus.DONE) {
+        yield* thread.waitUntilDone();
+      }
+    }
+  }
+
+  /**
+   * Restart this thread in-place.
+   */
   public restart(): void {
+    this.generation++;
     this.runningScript = this.trigger.startScript(this.target);
-    this.status = ThreadStatus.RUNNING;
+    this.unpark();
   }
 }

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -8,24 +8,10 @@ type TriggerOption =
 
 type TriggerOptions = Partial<Record<string, TriggerOption>>;
 
-export enum RunStatus {
-  /** This script is currently running. */
-  RUNNING,
-  /**
-   * This script is waiting for a promise, or waiting for other scripts.
-   * @todo This requires runtime support.
-   */
-  // PARKED,
-  /** This script is finished running. */
-  DONE,
-}
-
 export default class Trigger {
   public trigger;
   private options: TriggerOptions;
   private _script: GeneratorFunction;
-  private _runningScript: Generator | undefined;
-  public status: RunStatus;
 
   public constructor(
     trigger: symbol,
@@ -47,8 +33,6 @@ export default class Trigger {
       this.options = optionsOrScript as TriggerOptions;
       this._script = script;
     }
-
-    this.status = RunStatus.DONE;
   }
 
   public get isEdgeActivated(): boolean {
@@ -86,16 +70,8 @@ export default class Trigger {
     return true;
   }
 
-  public start(target: Sprite | Stage): void {
-    this.status = RunStatus.RUNNING;
-    this._runningScript = this._script.call(target);
-  }
-
-  public step(): void {
-    if (!this._runningScript) return;
-    if (this._runningScript.next().done) {
-      this.status = RunStatus.DONE;
-    }
+  public startScript(target: Sprite | Stage): Generator {
+    return this._script.call(target);
   }
 
   public clone(): Trigger {

--- a/src/Watcher.ts
+++ b/src/Watcher.ts
@@ -29,7 +29,7 @@ type WatcherOptions = {
 export default class Watcher {
   public value: () => WatcherValue;
   public setValue: (value: number) => void;
-  private _previousValue: unknown | symbol;
+  private _previousValue: unknown;
   private color: Color;
   private _label!: string;
   private _x!: number;

--- a/src/lib/yielding.ts
+++ b/src/lib/yielding.ts
@@ -1,7 +1,9 @@
+import { ThreadEffect } from "../Thread";
+
 /**
  * Utility type for a generator function that yields nothing until eventually
  * resolving to a value. Used extensively in Leopard and defined here so we
  * don't have to type out the full definition each time (and also so I don't
  * have to go back and change it everywhere if this type turns out to be wrong).
  */
-export type Yielding<T> = Generator<void, T, void>;
+export type Yielding<T> = Generator<ThreadEffect | undefined, T, void>;

--- a/src/renderer/Drawable.ts
+++ b/src/renderer/Drawable.ts
@@ -410,7 +410,9 @@ export default class Drawable {
   private _warnBadSize(description: string, treating: string): void {
     if (!this._warnedBadSize) {
       const { name } = this._sprite.constructor;
-      console.warn(`Expected a number, sprite ${name} size is ${description}. Treating as ${treating}.`);
+      console.warn(
+        `Expected a number, sprite ${name} size is ${description}. Treating as ${treating}.`
+      );
       this._warnedBadSize = true;
     }
   }

--- a/src/renderer/ShaderManager.ts
+++ b/src/renderer/ShaderManager.ts
@@ -59,12 +59,7 @@ class ShaderManager {
   }
 
   // Creates and compiles a vertex or fragment shader from the given source code.
-  private _createShader(
-    source: string,
-    type:
-      | WebGLRenderingContext["FRAGMENT_SHADER"]
-      | WebGLRenderingContext["VERTEX_SHADER"]
-  ): WebGLShader {
+  private _createShader(source: string, type: number): WebGLShader {
     const gl = this.gl;
     const shader = gl.createShader(type);
     if (!shader) throw new Error("Could not create shader.");

--- a/src/renderer/Skin.ts
+++ b/src/renderer/Skin.ts
@@ -28,9 +28,7 @@ export default abstract class Skin {
   // Helper function to create a texture from an image and handle all the boilerplate.
   protected _makeTexture(
     image: HTMLImageElement | HTMLCanvasElement | null,
-    filtering:
-      | WebGLRenderingContext["NEAREST"]
-      | WebGLRenderingContext["LINEAR"]
+    filtering: number
   ): WebGLTexture {
     const gl = this.gl;
     const glTexture = gl.createTexture();


### PR DESCRIPTION
Depends on #210.

This PR makes a few changes as progress towards #212:
- Instead of stepping each script once per frame, we do what Scratch does and keep going until a redraw is requested or we run out of frametime.
- Therefore, requesting redraws has also been implemented. Most functions which cause something visual to change on-screen request a redraw.
- The state that corresponds to a *running* script (namely the generator) has been moved out of `Trigger` and into its own class called `Thread`. Threads can:
- Be "parked"--if it is waiting for a promise to resolve, it will park itself until the promise resolves.
- Yield *to* another thread--that is, if the other thread is parked, the yielding thread will park itself as well, and ask the other thread to wake it up.
- Be restarted in-place, without worrying about stale promise state.

Generator functions that are running as Leopard threads can await promises without having to be async themselves using the new `Thread.await` function.